### PR TITLE
all: store JIDs that match caps hashes

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -341,7 +341,7 @@ func newClientHandler(configPath string, client *client.Client, pane *ui.UI, db 
 			go func() {
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
-				err := db.UpdateDisco(ctx, e.Caps, func(ctx context.Context) (disco.Info, error) {
+				err := db.UpdateDisco(ctx, e.From, e.Caps, func(ctx context.Context) (disco.Info, error) {
 					info, err := disco.GetInfo(ctx, e.Caps.Node+"#"+e.Caps.Ver, e.From, client.Session)
 					if err != nil {
 						return info, err

--- a/schema.sql
+++ b/schema.sql
@@ -96,3 +96,12 @@ CREATE TABLE IF NOT EXISTS discoIdentityCaps (
 	FOREIGN KEY (ident) REFERENCES discoIdentity(id) ON DELETE CASCADE,
 	UNIQUE (caps, ident)
 );
+
+CREATE TABLE IF NOT EXISTS discoJIDCaps (
+	id   INTEGER  PRIMARY KEY NOT NULL,
+	jid  TEXT                 NOT NULL,
+	caps INTEGER              NOT NULL,
+
+	FOREIGN KEY (caps) REFERENCES entityCaps(id) ON DELETE CASCADE,
+	UNIQUE (jid)
+);


### PR DESCRIPTION
Store the JIDs that were seen to match specific entity caps hashes so that we can look them up later.
We may want to dedup this with roster JIDs and other JIDs that we've seen at some point in the future.