### PR TITLE
internal/legacyboomarks: implement old bookmarks

### DIFF
--- a/internal/legacybookmarks/bookmarks.go
+++ b/internal/legacybookmarks/bookmarks.go
@@ -1,0 +1,73 @@
+// Copyright 2022 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+// Package legacybookmarks implements private XML based bookmarks.
+package legacybookmarks
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+
+	"mellium.im/communique/internal/privatexml"
+	"mellium.im/xmlstream"
+	"mellium.im/xmpp"
+	"mellium.im/xmpp/stanza"
+)
+
+// NS is the namespace used by this package.
+const NS = `storage:bookmarks`
+
+// Fetch returns an iterator over the list of bookmarks.
+// The session may block until the iterator is closed.
+func Fetch(ctx context.Context, s *xmpp.Session) *Iter {
+	return FetchIQ(ctx, stanza.IQ{}, s)
+}
+
+// FetchIQ is like Fetch but it allows you to customize the IQ.
+// Changing the type of the provided IQ has no effect.
+func FetchIQ(ctx context.Context, iq stanza.IQ, s *xmpp.Session) *Iter {
+	r, err := privatexml.GetIQ(ctx, iq, s, xml.Name{Space: NS, Local: "storage"})
+	if err != nil {
+		return &Iter{err: err}
+	}
+	tok, err := r.Token()
+	if err != nil {
+		/* #nosec */
+		r.Close()
+		return &Iter{err: err}
+	}
+	_, ok := tok.(xml.StartElement)
+	if !ok {
+		/* #nosec */
+		r.Close()
+		return &Iter{err: fmt.Errorf("legacybookmarks: expected start token, got %T %[1]v", tok)}
+	}
+
+	return &Iter{iter: xmlstream.NewIter(r)}
+}
+
+// // Set adds or updates a bookmark.
+// // Due to the nature of the legacy boomkarks spec, Set must first fetch the
+// // bookmarks then re-upload the entire list, making it very inefficient.
+// // There is also greater potential for race conditions if multiple cilents try
+// // to upload different bookmark lists at once.
+// func Set(ctx context.Context, s *xmpp.Session, b bookmarks.Bookmark) error {
+// 	return SetIQ(ctx, stanza.IQ{}, s, b)
+// }
+//
+// // SetIQ is like Set but it allows you to customize the IQ.
+// // Changing the type of the provided IQ has no effect.
+// func SetIQ(ctx context.Context, iq stanza.IQ, s *xmpp.Session, b bookmarks.Bookmark) error {
+// 	iq.Type = stanza.SetIQ
+//
+// 	iter := FetchIQ(ctx, iq, s)
+// 	// Normally we would just iterate (and would immediately break and then check
+// 	// the error), but since we need to first open the set IQ before we iterate go
+// 	// ahead and check for errors so that we don't start a query that we can't
+// 	// finish.
+// 	if err := iter.Err(); err != nil {
+// 		return err
+// 	}
+// }

--- a/internal/legacybookmarks/iter.go
+++ b/internal/legacybookmarks/iter.go
@@ -1,0 +1,67 @@
+// Copyright 2022 The Mellium Contributors.
+// Use of this source code is governed by the BSD 2-clause
+// license that can be found in the LICENSE file.
+
+package legacybookmarks
+
+import (
+	"encoding/xml"
+
+	"mellium.im/xmlstream"
+	"mellium.im/xmpp/bookmarks"
+)
+
+// Iter is an iterator over bookmarks.
+type Iter struct {
+	iter    *xmlstream.Iter
+	current bookmarks.Bookmark
+	err     error
+}
+
+// Next returns true if there are more items to decode.
+func (i *Iter) Next() bool {
+	if i.err != nil || !i.iter.Next() {
+		return false
+	}
+	start, r := i.iter.Current()
+	// If we encounter a lone token that doesn't begin with a start element (eg.
+	// a comment) skip it. This should never happen with XMPP, but we don't want
+	// to panic in case this somehow happens so just skip it.
+	// Similarly, if we encounter a payload type we don't recognize, skip it (this
+	// will likely happen as we don't support url bookmarks, so we'll skip those).
+	if start == nil || start.Name.Local != "conference" {
+		return i.Next()
+	}
+	d := xml.NewTokenDecoder(xmlstream.MultiReader(xmlstream.Token(*start), r))
+	bookmark := bookmarks.Bookmark{}
+	i.err = d.Decode(&bookmark)
+	if i.err != nil {
+		return false
+	}
+	i.current = bookmark
+	return true
+}
+
+// Err returns the last error encountered by the iterator (if any).
+func (i *Iter) Err() error {
+	if i.err != nil {
+		return i.err
+	}
+
+	return i.iter.Err()
+}
+
+// Bookmark returns the last bookmark parsed by the iterator.
+func (i *Iter) Bookmark() bookmarks.Bookmark {
+	return i.current
+}
+
+// Close indicates that we are finished with the given iterator and processing
+// the stream may continue.
+// Calling it multiple times has no effect.
+func (i *Iter) Close() error {
+	if i.iter == nil {
+		return nil
+	}
+	return i.iter.Close()
+}


### PR DESCRIPTION
This is implemented here instead of the main package because I anticipate use of legacy bookmarks dropping off and I don't think there's any need to clutter up the main package with something that will only have to be deprecated down the line. That being said, it is still widely used  (mellium/xmpp#258) at the moment, so it must be implemented *somewhere*.